### PR TITLE
Add output directory handling for SVG to PNG conversion

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -2,44 +2,32 @@ import os
 from wand.color import Color
 from wand.image import Image
 
-# Utility function to swap the file extension to .png
 def swap_file_ext(filepath: str, newExt: str) -> str:
-    splitpath = filepath.split('.')
-    splitpath.pop(len(splitpath) - 1)  # Remove the old extension
-    return '.'.join(splitpath) + '.' + newExt
+  splitpath = filepath.split('.')
+  splitpath.pop(len(splitpath) - 1)
+  return '.'.join(splitpath) + '.' + newExt
 
-# Convert a single SVG file to PNG and save it in the output directory
 def convert_svg_to_png(filepath: str, outputdir: str) -> str:
-    # Ensure the output directory exists
-    os.makedirs(outputdir, exist_ok=True)
+  os.makedirs(outputdir, exist_ok=True)
+  filename = os.path.basename(filepath)
+  updatedFilepath = os.path.join(outputdir, swap_file_ext(filename, "png"))
+  with Image(filename=filepath, background=Color("transparent"), resolution=144) as img:
+    img.format = 'png'
+    img.save(filename=updatedFilepath)
+  return updatedFilepath
 
-    # Get the filename without directory
-    filename = os.path.basename(filepath)
-    
-    # Update the file path with the output directory and .png extension
-    updatedFilepath = os.path.join(outputdir, swap_file_ext(filename, "png"))
-    
-    # Convert SVG to PNG using ImageMagick (via Wand)
-    with Image(filename=filepath, background=Color("transparent"), resolution=144) as img:
-        img.format = 'png'
-        img.save(filename=updatedFilepath)  # Save the image as PNG
-    
-    return updatedFilepath
-
-# Convert multiple SVG files to PNGs and save them to the output directory
 def convert_svgs_to_pngs(filepaths: list[str], outputdir: str) -> list[str]:
-    pngpaths = []
-    for filepath in filepaths:
-        # Convert each SVG file and append the new PNG file path
-        pngpath = convert_svg_to_png(filepath, outputdir)
-        pngpaths.append(pngpath)
-    return pngpaths
+  pngpaths = []
+  for filepath in filepaths:
+    pngpath = convert_svg_to_png(filepath, outputdir)
+    pngpaths.append(pngpath)
+  return pngpaths
 
-# Fetch file paths with a specific extension (e.g., .svg) in a directory
 def get_filepaths_by_extension(dir: str, ext: str) -> list[str]:
-    filepaths = []
-    for subdir, dirs, files in os.walk(dir):
-        for file in files:
-            if file.lower().endswith(ext):  # Case-insensitive match for extension
-                filepaths.append(os.path.join(subdir, file))
-    return filepaths
+  svgpaths: list[str] = []
+  for subdir, dirs, files in os.walk(dir):
+    for file in files:
+      filepath: str = os.path.join(subdir, file)
+      if (filepath.lower().endswith(ext)):
+        svgpaths.append(filepath)
+  return svgpaths

--- a/helpers.py
+++ b/helpers.py
@@ -2,31 +2,44 @@ import os
 from wand.color import Color
 from wand.image import Image
 
+# Utility function to swap the file extension to .png
 def swap_file_ext(filepath: str, newExt: str) -> str:
-  splitpath = filepath.split('.')
-  splitpath.pop(len(splitpath)-1)
-  return '.'.join(splitpath) + '.' + newExt
+    splitpath = filepath.split('.')
+    splitpath.pop(len(splitpath) - 1)  # Remove the old extension
+    return '.'.join(splitpath) + '.' + newExt
 
-def convert_svg_to_png(filepath: str) -> str:
-  updatedFilepath = swap_file_ext(filepath=filepath, newExt="png")
-  with Image(filename=filepath, background=Color("transparent"), resolution=144) as img:
-    img.format = 'png'
-    # img.compression_quality = 10
-    img.save(filename=updatedFilepath)
-  return updatedFilepath 
+# Convert a single SVG file to PNG and save it in the output directory
+def convert_svg_to_png(filepath: str, outputdir: str) -> str:
+    # Ensure the output directory exists
+    os.makedirs(outputdir, exist_ok=True)
 
-def convert_svgs_to_pngs(filepaths: list[str]) -> list[str]:
-  pngpaths = []
-  for filepath in filepaths:
-    pngpath = convert_svg_to_png(filepath)
-    pngpaths.append(pngpath)
-  return pngpaths
+    # Get the filename without directory
+    filename = os.path.basename(filepath)
+    
+    # Update the file path with the output directory and .png extension
+    updatedFilepath = os.path.join(outputdir, swap_file_ext(filename, "png"))
+    
+    # Convert SVG to PNG using ImageMagick (via Wand)
+    with Image(filename=filepath, background=Color("transparent"), resolution=144) as img:
+        img.format = 'png'
+        img.save(filename=updatedFilepath)  # Save the image as PNG
+    
+    return updatedFilepath
 
+# Convert multiple SVG files to PNGs and save them to the output directory
+def convert_svgs_to_pngs(filepaths: list[str], outputdir: str) -> list[str]:
+    pngpaths = []
+    for filepath in filepaths:
+        # Convert each SVG file and append the new PNG file path
+        pngpath = convert_svg_to_png(filepath, outputdir)
+        pngpaths.append(pngpath)
+    return pngpaths
+
+# Fetch file paths with a specific extension (e.g., .svg) in a directory
 def get_filepaths_by_extension(dir: str, ext: str) -> list[str]:
-  svgpaths: list[str] = []
-  for subdir, dirs, files in os.walk(dir):
-    for file in files:
-      filepath: str = os.path.join(subdir, file)
-      if (filepath.lower().endswith(ext)):
-        svgpaths.append(filepath)
-  return svgpaths
+    filepaths = []
+    for subdir, dirs, files in os.walk(dir):
+        for file in files:
+            if file.lower().endswith(ext):  # Case-insensitive match for extension
+                filepaths.append(os.path.join(subdir, file))
+    return filepaths

--- a/index.py
+++ b/index.py
@@ -1,28 +1,23 @@
 import sys
+import os
 from helpers import get_filepaths_by_extension, convert_svgs_to_pngs
 
 def main():
-    try:
-        # Input directory: either from the command-line argument or default to "./test-images"
-        rootdir = sys.argv[1] if len(sys.argv) > 1 else "./test-images"
-        
-        # Output directory: either from the command-line argument or default to "./output-images"
-        outputdir = sys.argv[2] if len(sys.argv) > 2 else "./output-images"
-        
-        print(f'Running SVG => PNG conversion in {rootdir}, outputting to {outputdir}')
-        
-        # Fetch SVG file paths
-        svgpaths = get_filepaths_by_extension(rootdir, 'svg')
-        
-        # Convert SVGs to PNGs and save them to the output directory
-        pngpaths = convert_svgs_to_pngs(svgpaths, outputdir)
+  try:
+    rootdir = sys.argv[1] if len(sys.argv) > 1 else "./test-images"
+    outputdir = sys.argv[2] if len(sys.argv) > 2 else os.path.join(rootdir, "converted-pngs")
 
-        print('\nAll done. Here are your generated PNG paths:')
-        print('\n'.join(pngpaths))
+    print(f'Running SVG => PNG conversion in {rootdir}, outputting to {outputdir}')
 
-        sys.exit(0)
-    except IndexError:
-        print("Missing filepath")
-        sys.exit(1)
+    svgpaths = get_filepaths_by_extension(rootdir, 'svg')
+    pngpaths = convert_svgs_to_pngs(svgpaths, outputdir)
+
+    print('\nAll done. Here are your generated PNG paths:')
+    print('\n'.join(pngpaths))
+
+    sys.exit(0)
+  except IndexError:
+    print("Missing filepath")
+    sys.exit(1)
 
 main()

--- a/index.py
+++ b/index.py
@@ -2,19 +2,27 @@ import sys
 from helpers import get_filepaths_by_extension, convert_svgs_to_pngs
 
 def main():
-  try:
-    rootdir = sys.argv[1] if 1 in range(len(sys.argv)) else "./test-images"
-    print('Running SVG => PNG conversion in ' + rootdir)
-    
-    svgpaths = get_filepaths_by_extension(rootdir, 'svg')
-    pngpaths = convert_svgs_to_pngs(svgpaths)
+    try:
+        # Input directory: either from the command-line argument or default to "./test-images"
+        rootdir = sys.argv[1] if len(sys.argv) > 1 else "./test-images"
+        
+        # Output directory: either from the command-line argument or default to "./output-images"
+        outputdir = sys.argv[2] if len(sys.argv) > 2 else "./output-images"
+        
+        print(f'Running SVG => PNG conversion in {rootdir}, outputting to {outputdir}')
+        
+        # Fetch SVG file paths
+        svgpaths = get_filepaths_by_extension(rootdir, 'svg')
+        
+        # Convert SVGs to PNGs and save them to the output directory
+        pngpaths = convert_svgs_to_pngs(svgpaths, outputdir)
 
-    print('\nAll done. Here are your generated PNG paths:')
-    print('\n'.join(pngpaths))
+        print('\nAll done. Here are your generated PNG paths:')
+        print('\n'.join(pngpaths))
 
-    sys.exit(0)
-  except IndexError:
-    print ("Missing filepath")
-    sys.exit(1)
+        sys.exit(0)
+    except IndexError:
+        print("Missing filepath")
+        sys.exit(1)
 
 main()


### PR DESCRIPTION
This pull request introduces the functionality to handle output directories for SVG to PNG conversion. Users can now specify an output directory where the converted PNG files will be saved. If no output directory is provided, the files will be saved in a converted-pngs folder within the input directory by default. This change enhances flexibility and allows better organization of the output files.

We have noted that there is no license on your repo, so before we start using it, we need an open-source license added to this repository, something like MIT or GPL or any license that you think is open-source enough. Please add the license; otherwise, we will have no choice but to reconsider using this repository.